### PR TITLE
Add configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0
+
+* [FEATURE] Configuration class to store api token
+
 ## 0.6.0
 
 * [CHANGE] Use pure ruby dependencies

--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -4,8 +4,8 @@ module Webflow
   class Client
     HOST = 'https://api.webflow.com'
 
-    def initialize(token)
-      @token = token
+    def initialize(token = nil)
+      @token = Webflow.config.api_token || token
       @rate_limit = {}
     end
 

--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -5,7 +5,7 @@ module Webflow
     HOST = 'https://api.webflow.com'
 
     def initialize(token = nil)
-      @token = Webflow.config.api_token || token
+      @token = token || Webflow.config.api_token
       @rate_limit = {}
     end
 

--- a/lib/webflow/config.rb
+++ b/lib/webflow/config.rb
@@ -1,0 +1,15 @@
+module Webflow
+  class << self
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      yield config
+    end
+  end
+
+  class Config
+    attr_accessor :api_token
+  end
+end

--- a/lib/webflow/ruby.rb
+++ b/lib/webflow/ruby.rb
@@ -1,2 +1,3 @@
 require 'webflow/version'
+require 'webflow/config'
 require 'webflow/client'

--- a/test/webflow_client_test.rb
+++ b/test/webflow_client_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class WebflowClientTest < Minitest::Test
+  def test_it_uses_configured_api_token_when_it_exists
+    Webflow.config.api_token = 'api_token'
+
+    client = Webflow::Client.new('given_token')
+
+    assert_equal('api_token', client.instance_variable_get('@token'))
+  end
+
+  def test_it_uses_given_api_token_when_configured_token_does_not_exist
+    Webflow.config.api_token = nil
+
+    client = Webflow::Client.new('given_token')
+
+    assert_equal('given_token', client.instance_variable_get('@token'))
+  end
+end

--- a/test/webflow_client_test.rb
+++ b/test/webflow_client_test.rb
@@ -1,19 +1,19 @@
 require 'test_helper'
 
 class WebflowClientTest < Minitest::Test
-  def test_it_uses_configured_api_token_when_it_exists
+  def test_it_prefers_given_token_over_configured_api_token
     Webflow.config.api_token = 'api_token'
 
     client = Webflow::Client.new('given_token')
 
-    assert_equal('api_token', client.instance_variable_get('@token'))
+    assert_equal('given_token', client.instance_variable_get('@token'))
   end
 
-  def test_it_uses_given_api_token_when_configured_token_does_not_exist
-    Webflow.config.api_token = nil
+  def test_it_uses_configured_api_token_when_token_is_not_given
+    Webflow.config.api_token = 'api_token'
 
-    client = Webflow::Client.new('given_token')
+    client = Webflow::Client.new
 
-    assert_equal('given_token', client.instance_variable_get('@token'))
+    assert_equal('api_token', client.instance_variable_get('@token'))
   end
 end

--- a/test/webflow_config_test.rb
+++ b/test/webflow_config_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class WebflowConfigTest < Minitest::Test
+  def test_it_saves_api_token
+    config.api_token = 'api_token'
+
+    assert_equal('api_token', config.api_token)
+
+    config.api_token = nil
+  end
+
+  def config
+    @config ||= Webflow::Config.new
+  end
+end


### PR DESCRIPTION
This is to avoid repeating the API token every time we need a client.

Usage would look like this:

```ruby
Webflow.configure do |config|
  config.api_token = 'your_api_token'
end
```

From this point on, any new instance of `Webflow::Client` will have `'your_api_token'` as default.

