### PR TITLE
Add error details to raised validation errors

### DIFF
--- a/lib/webflow/error.rb
+++ b/lib/webflow/error.rb
@@ -28,7 +28,12 @@ module Webflow
     def initialize(data)
       @data = data
 
-      super(data['msg'])
+      error_message = <<~END_OF_ERROR
+        #{data['msg']}
+        #{(data['problems'] || []).join("\n")}
+      END_OF_ERROR
+
+      super(error_message)
     end
   end
 end

--- a/test/fixtures/cassettes/test_raises_with_error_details.yml
+++ b/test/fixtures/cassettes/test_raises_with_error_details.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.webflow.com/collections/58c9a554a118f71a388bcc89/items
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"_archived":false,"_draft":false,"name":5}}'
+    headers:
+      Authorization:
+      - Bearer 1f0da5c9368af9cb2dcd65d22a6600a8ffa069f70729e129a09787203bc2c2be
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 31 Jan 2021 17:50:45 GMT
+      Etag:
+      - W/"c5-62e2d870"
+      X-Response-Time:
+      - 2.000ms
+      X-Wf-Rid:
+      - b0133f4a-0b85-4aaa-b9db-77a8a74f7caf
+      Content-Length:
+      - '197'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"msg":"Validation Failure","code":400,"name":"ValidationError","path":"/collections/58c9a554a118f71a388bcc89/items","err":"ValidationError: Validation Failure","problems":["Field ''name'': Expected value to be a single line: ''Monday:\\n'' +\n  ''Fever\\n''"],"problem_data":[{"slug":"name", "msg":"Expected value to be a single line","value":"''Monday:\\n'' +\n  ''Fever\\n''"}]}'
+    http_version:
+  recorded_at: Sun, 31 Jan 2021 17:50:45 GMT
+recorded_with: VCR 5.1.0

--- a/test/webflow_test.rb
+++ b/test/webflow_test.rb
@@ -87,6 +87,7 @@ class WebflowTest < Minitest::Test
       }
       begin
         client.create_item(COLLECTION_ID, data)
+        raise 'Unreachable code'
       rescue => err
         error = {"msg"=>"'fields.name' is required", "code"=>400, "name"=>"ValidationError", "path"=>"/collections/58c9a554a118f71a388bcc89/items", "err"=>"ValidationError: 'fields.name' is required"}
         assert_equal(error, err.data)

--- a/test/webflow_test.rb
+++ b/test/webflow_test.rb
@@ -95,6 +95,29 @@ class WebflowTest < Minitest::Test
     end
   end
 
+  def test_raises_with_error_details
+    VCR.use_cassette('test_raises_with_error_details') do
+      data = {
+        _archived:  false,
+        _draft:     false,
+        name:    <<~EOS
+          Monday:
+          Fever
+        EOS
+      }
+      begin
+        client.create_item(COLLECTION_ID, data)
+        raise 'Unreachable code'
+      rescue => err
+        error = <<~END_OF_ERROR
+          Validation Failure
+          Field 'name': Expected value to be a single line: 'Monday:\\n' +\n  'Fever\\n'
+        END_OF_ERROR
+        assert_equal(error, err.message)
+      end
+    end
+  end
+
   def test_it_paginates_items
     VCR.use_cassette('test_it_paginates_items') do
       names = ['Test 1', 'Test 2', 'Test 3', 'Test 4']


### PR DESCRIPTION
WebFlow API sometimes provides the `problems` array field which sometimes adds more details about the returned error.
In my case, I was receiving "ValidationError" back, but I didn't know which field failed validation and why.

This PR adds the `problems` array to the raised error message so that the users of webflow-ruby can get more information into what caused the error.

https://developers.webflow.com/#errors

PS This was difficult to test. I ran the test by connecting to my WebFlow site and then manually changed the VCR cassette. Perhaps it would be best to re-record this after you add the validation on `name` to be on a single line.


### Before

```
Webflow::Error: Validation Failure
/Users/viktor/.rvm/gems/ruby-2.6.6/gems/webflow-ruby-1.2.0/lib/webflow/client.rb:135:in `request'
/Users/viktor/.rvm/gems/ruby-2.6.6/gems/webflow-ruby-1.2.0/lib/webflow/client.rb:113:in `post'
/Users/viktor/.rvm/gems/ruby-2.6.6/gems/webflow-ruby-1.2.0/lib/webflow/client.rb:94:in `create_item'
```

### After

```
Webflow::Error: Validation Failure
Field 'name': Expected value to be a single line: 'Monday:\r\n' +
  'Fever\r\n'
/Users/viktor/Developer/Ruby/webflow-ruby/lib/webflow/client.rb:135:in `request'
/Users/viktor/Developer/Ruby/webflow-ruby/lib/webflow/client.rb:113:in `post'
/Users/viktor/Developer/Ruby/webflow-ruby/lib/webflow/client.rb:94:in `create_item'
```
