### PR TITLE
Expose validation errors

### DIFF
--- a/lib/webflow/error.rb
+++ b/lib/webflow/error.rb
@@ -1,17 +1,17 @@
 module Webflow
   class Error < StandardError
     # https://developers.webflow.com/#errors
-    # 400 	SyntaxError 	Request body was incorrectly formatted. Likely invalid JSON being sent up.
-    # 400 	InvalidAPIVersion 	Requested an invalid API version
-    # 400 	UnsupportedVersion 	Requested an API version that in unsupported by the requested route
-    # 400 	NotImplemented 	This feature is not currently implemented
-    # 400 	ValidationError 	Validation failure (see problems field in the response)
-    # 400 	Conflict 	Request has a conflict with existing data.
-    # 401 	Unauthorized 	Provided access token is invalid or does not have access to requested resource
-    # 404 	NotFound 	Requested resource not found
-    # 429 	RateLimit 	The rate limit of the provided access_token has been reached. Please have your application respect the X-RateLimit-Remaining header we include on API responses.
-    # 500 	ServerError 	We had a problem with our server. Try again later.
-    # 400 	UnknownError 	An error occurred which is not enumerated here, but is not a server error.
+    # 400 SyntaxError - Request body was incorrectly formatted. Likely invalid JSON being sent up.
+    # 400 InvalidAPIVersion - Requested an invalid API version
+    # 400 UnsupportedVersion - Requested an API version that in unsupported by the requested route
+    # 400 NotImplemented - This feature is not currently implemented
+    # 400 ValidationError - Validation failure (see problems field in the response)
+    # 400 Conflict - Request has a conflict with existing data.
+    # 401 Unauthorized - Provided access token is invalid or does not have access to requested resource
+    # 404 NotFound - Requested resource not found
+    # 429 RateLimit - The rate limit of the provided access_token has been reached. Please have your application respect the X-RateLimit-Remaining header we include on API responses.
+    # 500 ServerError - We had a problem with our server. Try again later.
+    # 400 UnknownError - An error occurred which is not enumerated here, but is not a server error.
     #
     # Sample error response
     #
@@ -28,7 +28,11 @@ module Webflow
     def initialize(data)
       @data = data
 
-      super(data['msg'])
+      if data['msg'] == 'Validation Failure'
+        super("#{data['msg']} - #{data['problems'].join(", ")}")
+      else
+        super(data['msg'])
+      end
     end
   end
 end

--- a/lib/webflow/version.rb
+++ b/lib/webflow/version.rb
@@ -1,3 +1,3 @@
 module Webflow
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Webflow returns validations errors in the problems property. We can add them to the exception message to ease debugging.