### PR TITLE
Gracefully handle rate limit errors when response body is not json

### DIFF
--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -131,8 +131,8 @@ module Webflow
 
       track_rate_limit(response.headers)
 
-      result = JSON.parse(response.body)
-      raise Webflow::Error.new(result) if response.code >= 400
+      result = maybe_parsed_json(response.body)
+      raise Webflow::Error.new(result || response.body) if response.code >= 400
 
       result
     end
@@ -140,6 +140,12 @@ module Webflow
     def track_rate_limit(headers)
       rate_limit = headers.select { |key, value| key =~ /X-Ratelimit/ }.to_h
       @rate_limit = rate_limit unless rate_limit.empty?
+    end
+
+    def maybe_parsed_json(hopefully_json)
+      JSON.parse(hopefully_json)
+    rescue JSON::ParserError
+      nil
     end
   end
 end

--- a/lib/webflow/error.rb
+++ b/lib/webflow/error.rb
@@ -1,17 +1,17 @@
 module Webflow
   class Error < StandardError
     # https://developers.webflow.com/#errors
-    # 400 	SyntaxError 	Request body was incorrectly formatted. Likely invalid JSON being sent up.
-    # 400 	InvalidAPIVersion 	Requested an invalid API version
-    # 400 	UnsupportedVersion 	Requested an API version that in unsupported by the requested route
-    # 400 	NotImplemented 	This feature is not currently implemented
-    # 400 	ValidationError 	Validation failure (see problems field in the response)
-    # 400 	Conflict 	Request has a conflict with existing data.
-    # 401 	Unauthorized 	Provided access token is invalid or does not have access to requested resource
-    # 404 	NotFound 	Requested resource not found
-    # 429 	RateLimit 	The rate limit of the provided access_token has been reached. Please have your application respect the X-RateLimit-Remaining header we include on API responses.
-    # 500 	ServerError 	We had a problem with our server. Try again later.
-    # 400 	UnknownError 	An error occurred which is not enumerated here, but is not a server error.
+    # 400   SyntaxError   Request body was incorrectly formatted. Likely invalid JSON being sent up.
+    # 400   InvalidAPIVersion   Requested an invalid API version
+    # 400   UnsupportedVersion   Requested an API version that in unsupported by the requested route
+    # 400   NotImplemented   This feature is not currently implemented
+    # 400   ValidationError   Validation failure (see problems field in the response)
+    # 400   Conflict   Request has a conflict with existing data.
+    # 401   Unauthorized   Provided access token is invalid or does not have access to requested resource
+    # 404   NotFound   Requested resource not found
+    # 429   RateLimit   The rate limit of the provided access_token has been reached. Please have your application respect the X-RateLimit-Remaining header we include on API responses.
+    # 500   ServerError   We had a problem with our server. Try again later.
+    # 400   UnknownError   An error occurred which is not enumerated here, but is not a server error.
     #
     # Sample error response
     #
@@ -28,7 +28,13 @@ module Webflow
     def initialize(data)
       @data = data
 
-      message = "#{data['msg']}#{': ' + Array(problems).join(', ') if problems?}"
+      if data.is_a?(Hash)
+        message = data['msg']
+        message += ": #{Array(problems).join(', ')}" if problems?
+      else
+        message = data
+      end
+
       super(message)
     end
 


### PR DESCRIPTION
When the rate limit is hit, the response body does not contain json, at least in some cases. By catching the ParserError we can  raise the Webflow::Error as intended.

Sorry for the formatting noise in error.rb, will remove it if you insist.