### PR TITLE
Delete: Allow passing `live` parameter

### DIFF
--- a/lib/webflow/client.rb
+++ b/lib/webflow/client.rb
@@ -98,8 +98,8 @@ module Webflow
       patch("/collections/#{item['_cid']}/items/#{item['_id']}", {fields: data}, live: live)
     end
 
-    def delete_item(item)
-      delete("/collections/#{item['_cid']}/items/#{item['_id']}")
+    def delete_item(item, live: false)
+      delete("/collections/#{item['_cid']}/items/#{item['_id']}", live: live)
     end
 
     private
@@ -118,8 +118,9 @@ module Webflow
       request(path, method: :patch, params: params, data: data)
     end
 
-    def delete(path)
-      request(path, method: :delete)
+    def delete(path, live: nil)
+      params = { live: 'true' } if live
+      request(path, method: :delete, params: params)
     end
 
     def request(path, method: :get, params: nil, data: nil)


### PR DESCRIPTION
I've been constantly having issues with Webflow CMS items not being properly synced.
I realized that removing the items is the most problematic.

I ended up publishing for every "delete".
I finally found a "cheaper" way to achieve this.
If we delete without `live: true`, the item will stay visible on the site until the site is published again.
If we delete with `live: true`, the item will be set as draft and not visible on the site, but it will be visible in the Webflow CMS.
We can call delete with `live: true` to remove it from the site (and make it a draft) and then call delete again, without `live: true` to remove the item from Webflow completely:

```ruby
client.delete_item({ '_cid' => collection['_id'], '_id' => webflow_item_id }, live: true)
client.delete_item({ '_cid' => collection['_id'], '_id' => webflow_item_id })
```

To allow this functionality, I need the support for `live:` keyword argument to `delete_item` method.